### PR TITLE
NV BE #69- 카카오 메시지 템플릿 변경

### DIFF
--- a/server/src/config/redis.ts
+++ b/server/src/config/redis.ts
@@ -208,24 +208,24 @@ const processJob: JobProcessor = async (job) => {
             // ========== 3단계: 메시지 전송 ==========
             for (const notice of settingFilteredNotices) {
               try {
-                // 메시지 내용 구성
-                const messageContent = `새 공지사항\n제목: ${notice.title}\n번호: ${notice.number}\n링크: ${notice.link}`;
+                // 카카오 메시지 전송 (피드 템플릿 사용)
+                // notice.description이 있으면 사용, 없으면 기본값 생성
+                const description = notice.description || `번호: ${notice.number}\n링크: ${notice.link}`;
+                // notice.imageUrl이 있으면 사용, 없으면 기본 이미지 사용
+                const imageUrl = notice.imageUrl || 'https://t1.daumcdn.net/cafeattach/1YmK3/560c6415d44b9ae3c5225a255541c3c2c1568643';
                 
-                // 카카오 메시지 전송
-                await sendKakaoMessage(setting.user_id, {
-                  object_type: 'text',
-                  text: messageContent,
-                  link: {
-                    web_url: notice.link,
-                    mobile_web_url: notice.link
-                  },
-                  button_title: '자세히 보기'
-                });
+                await sendKakaoMessage(
+                  setting.user_id,
+                  notice.title,
+                  description,
+                  imageUrl,
+                  notice.link
+                );
                 
-                // Message 저장
-                // getSettingsByDomainId에서 이미 _id가 문자열로 변환되어 반환됨
+                // Message 저장 (제목과 설명을 내용으로 저장)
+                const messageToSave = `[공지] ${notice.title}\n${description}`;
                 const settingId = setting._id || setting.id;
-                await saveMessage(settingId, messageContent, 'kakao');
+                await saveMessage(settingId, messageToSave, 'kakao');
                 
                 totalMessagesSent++;
                 console.log(`[Job] Setting "${setting.name}": 공지사항 #${notice.number} 메시지 전송 완료`);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,7 +3,7 @@ import dotenv from "dotenv";
 import mongoose from "mongoose";
 import { createClient } from "redis";
 import authRouter from "./routes/authRoutes.js";
-import testRouter from "./routes/testRoutes.js";
+import testRouter from "./test/kakaoMessageTest.js";
 import mainRoutes from "./routes/mainRoutes.js";
 import settingsRoutes from "./routes/settingsRoutes.js";
 import userRoutes from "./routes/userRoutes.js";

--- a/server/src/services/notificationService.ts
+++ b/server/src/services/notificationService.ts
@@ -5,7 +5,10 @@ import * as KakaoAPI from './kakaoAPIClient.js';
 // 사용자에게 카카오톡 메시지. BullMQ 워커에서 호출되는 것을 전제로 한 비즈니스 로직.
 export async function sendKakaoMessage(
   userId: string,
-  templateObject: any
+  title: string,
+  description: string,
+  imageUrl: string,
+  linkUrl: string
 ): Promise<any> {
   // 0. 사용자 정보 조회 및 알림 설정 확인
   // 크롤링/필터링 로직에서 사용하는 userId는 문자열 _id일 수 있으므로 findUserByIdString 사용
@@ -54,6 +57,27 @@ export async function sendKakaoMessage(
 
   try {
     // 3. 유효하거나 갱신된 accessToken으로 메시지 전송을 시도.
+    const templateObject = {
+      object_type: 'feed',
+      content: {
+        title: title,
+        description: description,
+        image_url: imageUrl,
+        link: {
+          web_url: linkUrl,
+          mobile_web_url: linkUrl
+        }
+      },
+      buttons: [
+        {
+          title: '자세히 보기',
+          link: {
+            web_url: linkUrl,
+            mobile_web_url: linkUrl
+          }
+        }
+      ]
+    };
     return await KakaoAPI.sendMemo(accessToken, templateObject);
   } catch (error: any) {
     // 4. 시도가 실패했을 경우 (예: 갱신 후에도 토큰이 유효하지 않거나 다른 이유)
@@ -78,6 +102,27 @@ export async function sendKakaoMessage(
       console.log(`토큰 재갱신 완료 (user: ${userId}), 메시지 전송을 재시도합니다.`);
       
       // 새로 발급받은 토큰으로 메시지 전송을 재시도.
+      const templateObject = {
+        object_type: 'feed',
+        content: {
+          title: title,
+          description: description,
+          image_url: imageUrl,
+          link: {
+            web_url: linkUrl,
+            mobile_web_url: linkUrl
+          }
+        },
+        buttons: [
+          {
+            title: '자세히 보기',
+            link: {
+              web_url: linkUrl,
+              mobile_web_url: linkUrl
+            }
+          }
+        ]
+      };
       return await KakaoAPI.sendMemo(newAccessToken, templateObject);
     }
 

--- a/server/src/test/kakaoMessageTest.ts
+++ b/server/src/test/kakaoMessageTest.ts
@@ -6,25 +6,21 @@ const router = Router();
 
 // BullMQ나 스케줄러와 같은 비동기 흐름을 거치지 않고, notificationService의 기능을 직접 테스트.
 // 카카오 메시지 전송 기능을 직접 테스트하기 위한 엔드포인트
-router.post('/kakao', authMiddleware, async (req, res) => {
-  const userId = req.userId;
+router.post('/kakao', async (req, res) => {
+  const { userId } = req.body; // userId를 req.body에서 직접 받음
 
   if (!userId) {
-    return res.status(400).json({ message: 'User ID를 찾을수없습니다.' });
+    return res.status(400).json({ message: 'User ID가 요청 본문에 없습니다.' });
   }
 
-  // 테스트용 메시지 템플릿
-  const dummyTemplate = {
-    object_type: 'text',
-    text: '[테스트] 이것은 더미 데이터로 보내는 테스트 메시지입니다.',
-    link: {
-      web_url: 'https://developers.kakao.com',
-      mobile_web_url: 'https://developers.kakao.com',
-    },
-  };
+  // 테스트용 Feed 메시지 데이터
+  const testTitle = '[테스트] 부경대학교 새 공지사항';
+  const testDescription = '새로운 공지사항이 등록되었습니다. 자세한 내용은 링크를 확인하세요.';
+  const testImageUrl = 'https://www.pknu.ac.kr/upload/raonkeditordata/2025/11/07/20251107_085933875_56906.jpg'; // 부경대 로고 또는 기본 이미지 URL
+  const testLinkUrl = 'https://www.pknu.ac.kr/main/163?action=view&no=722252';
 
   try {
-    await sendKakaoMessage(userId, dummyTemplate);
+    await sendKakaoMessage(userId, testTitle, testDescription, testImageUrl, testLinkUrl);
     return res.status(200).json({ message: '카카오 메시지를 성공적으로 보냈습니다.' });
   } catch (error: any) {
     console.error('카카오 메시지 전송 실패:', error.response?.data || error.message);
@@ -34,5 +30,4 @@ router.post('/kakao', authMiddleware, async (req, res) => {
     });
   }
 });
-
 export default router;


### PR DESCRIPTION
카카오 피드 메시지 템플릿으로 변경 -> 아직 크롤링 코드 imageurl 받아오지못해서 하드코딩된 이미지 url 사용중

**크롤링 쪽 코드 변경되는대로 수정 필요**

kakaoMessageTest 코드를 통해서 메시지 수신 확인됨.


<img width="355" height="466" alt="image" src="https://github.com/user-attachments/assets/508101cf-80a6-4fb4-bc69-85e1dd90691f" />

