### PR TITLE
NV BE #20 - Domain 및 관련 파일 복구, 프론트용 도메인 객체 추가

### DIFF
--- a/server/src/data/domainMeta.ts
+++ b/server/src/data/domainMeta.ts
@@ -1,0 +1,15 @@
+// 프론트용 하드코딩 데이터
+export const domainMeta: Record<string, { desc: string; icon: string }> = {
+  "취업": {
+    desc: "채용 공고를 한눈에 확인하세요.",
+    icon: "Briefcase",
+  },
+  "공모전": {
+    desc: "다양한 분야의 공모전 정보를 모았습니다.",
+    icon: "Trophy",
+  },
+  "정책지원": {
+    desc: "정부 및 기관의 각종 지원 사업 정보를 확인하세요.",
+    icon: "Building",
+  },
+};

--- a/server/src/services/mainService.ts
+++ b/server/src/services/mainService.ts
@@ -1,12 +1,20 @@
 import { findAllDomains } from "../repository/mongodb/domainRepository.js";
+import { domainMeta } from "../data/domainMeta.js";
 
 export async function getDomains() {
   const domains = await findAllDomains();
 
-  return domains.map((domain: any) => ({
-    id: domain._id,
-    name: domain.name,
-    url_list: domain.url_list,
-    keywords: domain.keywords,
-  }));
+  return domains.map((domain: any) => {
+    const meta = domainMeta[domain.name] || {
+      desc: "도메인 관련 최신 소식을 제공합니다.",
+      icon: "Globe",
+    };
+
+    return {
+      id: domain._id,
+      name: domain.name,
+      desc: meta.desc,
+      icon: meta.icon,
+    };
+  });
 }


### PR DESCRIPTION
Domain, domainRepository, initialDomains, mainService 파일들을 초기 상태로 복구
프론트용 도메인 객체 domainMeta.ts 추가

Domain 모델에서 desc, icon 필드는 제거  
    service 단에서 domainMeta.ts의 하드코딩 데이터를 불러와  id, name, desc, icon 필드만 프론트로 전달 
        -> 추후 DB에 desc, icon 필드 추가할 예정
    DB 구조 및 로직에 영향 X